### PR TITLE
Implement Message Transport abstract functionality #10

### DIFF
--- a/__tests__/message/index.ts
+++ b/__tests__/message/index.ts
@@ -2,13 +2,13 @@ import { Message } from '../../src/message';
 
 describe('Message Functionality', () => {
   it('should create a message', async () => {
-    const message = new Message({ createdBy: 'some.actionName', payload: { foo: 'bar' } });
+    const message = new Message({ type: 'some.actionName', payload: { foo: 'bar' } });
 
     expect(message).toHaveProperty('id');
     expect(message.id).toHaveLength(64);
     expect(message).toHaveProperty('createdAt');
     expect(message.createdAt).toBeInstanceOf(Date);
-    expect(message).toHaveProperty('createdBy', 'some.actionName');
+    expect(message).toHaveProperty('type', 'some.actionName');
     expect(message).toHaveProperty('payload', { foo: 'bar' });
   });
 });

--- a/__tests__/transport/eventemitter.ts
+++ b/__tests__/transport/eventemitter.ts
@@ -1,0 +1,27 @@
+import { EventEmitterTransport } from '../../src/transport/eventemitter';
+
+describe('Event Emitter Transport functionality', () => {
+  it('should emit an event', () => {
+    const transport = new EventEmitterTransport();
+    const event = 'test';
+    const data = {
+      test: 'test',
+    };
+    const listener = jest.fn();
+    transport.on(event, listener);
+    transport.emit(event, data);
+    expect(listener).toHaveBeenCalledWith(data);
+  });
+
+  it('should connect', () => {
+    const transport = new EventEmitterTransport();
+    const result = transport.connect();
+    expect(result).resolves.not.toThrow();
+  });
+
+  it('should disconnect', () => {
+    const transport = new EventEmitterTransport();
+    const result = transport.disconnect();
+    expect(result).resolves.not.toThrow();
+  });
+});

--- a/docs/message.md
+++ b/docs/message.md
@@ -13,11 +13,11 @@ new Message({
 ```
 
 Options:
-* createdBy [string] - name of the action who's created that message
+* type [string] - message type (service name, action name ot other message type)
 * payload [unknown0] - some usefully payload for the message
 
 Available data:
 * id [string] - unique randomly generated hex string with 64 characters length
 * createdAt [Date] - actual date of message creating
-* createdBy [string] - name of the action who's created that message
+* type [string] - message type (service name, action name ot other message type)
 * payload [unknown0] - some usefully payload for the message

--- a/docs/overview.puml
+++ b/docs/overview.puml
@@ -1,0 +1,31 @@
+@startuml
+' scale 1980 width
+
+'!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Container.puml
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Container.puml
+!define FONTAWESOME https://raw.githubusercontent.com/tupadr3/plantuml-icon-font-sprites/master//font-awesome
+!define FONTAWESOME5 https://raw.githubusercontent.com/tupadr3/plantuml-icon-font-sprites/master//font-awesome-5
+!define DEVICONS https://raw.githubusercontent.com/tupadr3/plantuml-icon-font-sprites/master//devicons
+!define GOVICONS https://raw.githubusercontent.com/tupadr3/plantuml-icon-font-sprites/master//govicons
+!define WEATHER https://raw.githubusercontent.com/tupadr3/plantuml-icon-font-sprites/master//weather
+!define MATERIAL https://raw.githubusercontent.com/tupadr3/plantuml-icon-font-sprites/master//material
+!define DEVICONS2 https://raw.githubusercontent.com/tupadr3/plantuml-icon-font-sprites/master//devicons2
+
+' Sprites https://github.com/tupadr3/plantuml-icon-font-sprites
+!include MATERIAL/message.puml
+!include MATERIAL/memory.puml
+
+Container(broker, "Message Broker", "Messages Delivery System", "Main responsibility of Message Broker is receive a message, delivery it to processor, wait a response, and delivery response to a waiter", $sprite="memory")
+Container(serializer, "Serializer", "Message Serializer", "Message serializer functionality pointed to represent data and payload into required format. Serializer should be the same for serializing and deserializing data", $sprite="message")
+Container(action, "Action", "Message Processor", "Functionality that expecting message from broker, processing that message and provides a response with results of message processing to the broker", $sprite="message")
+Container(logs, "Logs", "Logger", "Abstraction that provides possibility to get a log messages about actions and system activities. Error reporting and tracing", $sprite="message")
+Container(transport, "Transport", "Transport", "Physical message delivery to the messages exchange point", $sprite="message")
+
+Rel(transport, serializer, "Listening messages from the exchange point")
+Rel(serializer, broker, "Send message for routing to the required Action")
+Rel(broker, action, "Routing message to the required action")
+Rel(action, logs, "Log message processing data")
+Rel(action, broker, "Send response to the requester")
+Rel(broker, serializer, "Convert message to transport layer format")
+Rel(serializer, transport, "Send message to the exchange point")
+@enduml

--- a/docs/transport.md
+++ b/docs/transport.md
@@ -1,0 +1,20 @@
+## Transport
+
+Transport functionality implements "EventEmitter" interface. Additionally, it should have 2 methods:
+* connect [Promise] - connects to the transport network
+* disconnect [Promise] - disconnects from the transport network
+
+```typescript
+import { EventEmitterTransport } from './eventemitter';
+
+const transport = new EventEmitterTransport();
+transport.on('some.actionName', (message: Message<{test: string}>) => {
+  console.log(message);
+});
+
+transport.connect().then(() => {
+  transport.emit('some.actionName', {test: 'test'});
+});
+```
+
+To create your own transport, you should extend "Transport" class and replace behaviour of "connect", "disconnect" and other methods to apply EventsEmitter logic.

--- a/src/message/index.ts
+++ b/src/message/index.ts
@@ -5,9 +5,9 @@ import { randomBytes } from 'crypto';
  */
 interface MessageOptions<Payload> {
   /**
-   * Action name who's created that message
+   * Message type (service name, action name ot other message type)
    */
-  createdBy: string;
+  type: string;
   /**
    * Payload of message
    */
@@ -23,9 +23,9 @@ class Message<Payload> {
    */
   readonly id: string = randomBytes(32).toString('hex');
   /**
-   * Action name who's created that message
+   * Message type (service name, action name ot other message type)
    */
-  readonly createdBy: string;
+  readonly type: string;
   /**
    * Date when that message was actually created
    */
@@ -35,8 +35,8 @@ class Message<Payload> {
    */
   readonly payload: Payload;
 
-  constructor({ createdBy, payload }: MessageOptions<Payload>) {
-    this.createdBy = createdBy;
+  constructor({ type, payload }: MessageOptions<Payload>) {
+    this.type = type;
     this.payload = payload;
   }
 }

--- a/src/transport/eventemitter.ts
+++ b/src/transport/eventemitter.ts
@@ -1,0 +1,15 @@
+import { Transport } from './transport';
+
+class EventEmitterTransport extends Transport {
+  public connect(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  public disconnect(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+export {
+  EventEmitterTransport,
+};

--- a/src/transport/transport.ts
+++ b/src/transport/transport.ts
@@ -1,0 +1,10 @@
+import EventEmitter from 'events';
+
+abstract class Transport extends EventEmitter {
+  public abstract connect(): Promise<void>;
+  public abstract disconnect(): Promise<void>;
+}
+
+export {
+  Transport,
+};


### PR DESCRIPTION
## Transport

Transport functionality implements "EventEmitter" interface. Additionally, it should have 2 methods:
* connect [Promise] - connects to the transport network
* disconnect [Promise] - disconnects from the transport network

```typescript
import { EventEmitterTransport } from './eventemitter';

const transport = new EventEmitterTransport();
transport.on('some.actionName', (message: Message<{test: string}>) => {
  console.log(message);
});

transport.connect().then(() => {
  transport.emit('some.actionName', {test: 'test'});
});
```

To create your own transport, you should extend "Transport" class and replace behaviour of "connect", "disconnect" and other methods to apply EventsEmitter logic.

Resolves #10 